### PR TITLE
fix: avoid typechecking generated javascript modules

### DIFF
--- a/.changeset/eleven-parents-own.md
+++ b/.changeset/eleven-parents-own.md
@@ -1,0 +1,5 @@
+---
+"@acdh-oeaw/content-lib": patch
+---
+
+avoid typechecking generated javascript modules by adding `@ts-nocheck` directive

--- a/packages/content-lib/src/index.ts
+++ b/packages/content-lib/src/index.ts
@@ -168,7 +168,7 @@ function serialize(value: Map<string, any>): [string, Map<string, string>] {
 
 				debug(`Adding javascript import for "${filePath}".`);
 				const identifier = addImport(filePath);
-				addFiles(filePath, value.content);
+				addFiles(filePath, `// @ts-nocheck\n${value.content}`);
 
 				return identifier;
 			}


### PR DESCRIPTION
this adds a `@ts-nocheck` directive to generated javascript modules to avoid typechecking .js files (in projects with `allowJs` and `checkJs`) which don't have type annotations.