### PR TITLE
fix: sanitize output directory name

### DIFF
--- a/.changeset/petite-chairs-fail.md
+++ b/.changeset/petite-chairs-fail.md
@@ -1,0 +1,5 @@
+---
+"@acdh-oeaw/content-lib": patch
+---
+
+sanitize output directory name

--- a/packages/content-lib/src/index.ts
+++ b/packages/content-lib/src/index.ts
@@ -242,7 +242,10 @@ export async function createContentProcessor(config: ContentConfig): Promise<Con
 	for (const collection of config.collections) {
 		const absoluteDirectoryPath = addTrailingSlash(path.resolve(collection.directory));
 
-		const outputDirectoryPath = path.join(outputDirectoryBasePath, collection.name);
+		const outputDirectoryPath = path.join(
+			outputDirectoryBasePath,
+			collection.name.toLowerCase().replaceAll(/[^a-z0-9_-]/g, "-"),
+		);
 		await fs.mkdir(outputDirectoryPath, { recursive: true });
 
 		collections.push({


### PR DESCRIPTION
this ensures the output directory name, which is generated from the collection name, only includes alphanumeric characters, dashes and underscores, and is lowercase.