### PR TITLE
fix: clean output folder only immediately before writing new content

### DIFF
--- a/.changeset/neat-flowers-smash.md
+++ b/.changeset/neat-flowers-smash.md
@@ -1,0 +1,5 @@
+---
+"@acdh-oeaw/content-lib": minor
+---
+
+only clear output folder before writing new output, make `createContentProcessor` synchronous

--- a/apps/basic/scripts/generate-content.ts
+++ b/apps/basic/scripts/generate-content.ts
@@ -16,7 +16,7 @@ async function generate(): Promise<void> {
 	const { positionals } = parseArgs({ allowPositionals: true });
 	const mode = v.parse(positionalArgsSchema, positionals.at(0));
 
-	const processor = await createContentProcessor(config);
+	const processor = createContentProcessor(config);
 
 	async function build() {
 		log.info("Processing...");

--- a/apps/bench/scripts/generate-content.ts
+++ b/apps/bench/scripts/generate-content.ts
@@ -16,7 +16,7 @@ async function generate(): Promise<void> {
 	const { positionals } = parseArgs({ allowPositionals: true });
 	const mode = v.parse(positionalArgsSchema, positionals.at(0));
 
-	const processor = await createContentProcessor(config);
+	const processor = createContentProcessor(config);
 
 	async function build() {
 		log.info("Processing...");

--- a/apps/keystatic/scripts/generate-content.ts
+++ b/apps/keystatic/scripts/generate-content.ts
@@ -16,7 +16,7 @@ async function generate(): Promise<void> {
 	const { positionals } = parseArgs({ allowPositionals: true });
 	const mode = v.parse(positionalArgsSchema, positionals.at(0));
 
-	const processor = await createContentProcessor(config);
+	const processor = createContentProcessor(config);
 
 	async function build() {
 		log.info("Processing...");


### PR DESCRIPTION
this clears the output folder before writing new content, not when initializing the processor. this avoids the output folder being empty for a couple of seconds, which confuses the typescript language server in IDEs.

this has the sideeffect that `createContentProcessor` can now be synchronous.