### PR TITLE
feat: provide collections to transform context

### DIFF
--- a/.changeset/busy-dots-mate.md
+++ b/.changeset/busy-dots-mate.md
@@ -1,0 +1,5 @@
+---
+"@acdh-oeaw/content-lib": minor
+---
+
+provide collections to transform context

--- a/packages/content-lib/src/index.ts
+++ b/packages/content-lib/src/index.ts
@@ -48,6 +48,7 @@ interface CollectionItem {
 }
 
 interface TransformContext {
+	collections: Array<Collection>;
 	createImportDeclaration: (path: string) => ImportDeclaration;
 	createJavaScriptImport: (content: string) => JavaScriptImport;
 	createJsonImport: (content: string) => JsonImport;
@@ -240,6 +241,7 @@ export async function createContentProcessor(config: ContentConfig): Promise<Con
 	const collections: Array<Collection> = [];
 
 	const context: TransformContext = {
+		collections,
 		createImportDeclaration,
 		createJavaScriptImport,
 		createJsonImport,


### PR DESCRIPTION
this provides the full collections list to the transform context. this is useful to e.g. resolve lists of ids to full documents in other collections (think personId => person from `contextcollections.people.data.get(personId)`).

in the future we may be more restrictive what is exposed via context.