### PR TITLE
fix: ensure directory exists for file watcher

### DIFF
--- a/.changeset/neat-flowers-smash.md
+++ b/.changeset/neat-flowers-smash.md
@@ -2,4 +2,4 @@
 "@acdh-oeaw/content-lib": minor
 ---
 
-only clear output folder before writing new output, make `createContentProcessor` synchronous
+only clear output folder before writing new output

--- a/.changeset/public-times-tickle.md
+++ b/.changeset/public-times-tickle.md
@@ -1,0 +1,5 @@
+---
+"@acdh-oeaw/content-lib": patch
+---
+
+ensure directory exists for file watcher

--- a/apps/basic/scripts/generate-content.ts
+++ b/apps/basic/scripts/generate-content.ts
@@ -16,7 +16,7 @@ async function generate(): Promise<void> {
 	const { positionals } = parseArgs({ allowPositionals: true });
 	const mode = v.parse(positionalArgsSchema, positionals.at(0));
 
-	const processor = createContentProcessor(config);
+	const processor = await createContentProcessor(config);
 
 	async function build() {
 		log.info("Processing...");

--- a/apps/bench/scripts/generate-content.ts
+++ b/apps/bench/scripts/generate-content.ts
@@ -16,7 +16,7 @@ async function generate(): Promise<void> {
 	const { positionals } = parseArgs({ allowPositionals: true });
 	const mode = v.parse(positionalArgsSchema, positionals.at(0));
 
-	const processor = createContentProcessor(config);
+	const processor = await createContentProcessor(config);
 
 	async function build() {
 		log.info("Processing...");

--- a/apps/keystatic/scripts/generate-content.ts
+++ b/apps/keystatic/scripts/generate-content.ts
@@ -16,7 +16,7 @@ async function generate(): Promise<void> {
 	const { positionals } = parseArgs({ allowPositionals: true });
 	const mode = v.parse(positionalArgsSchema, positionals.at(0));
 
-	const processor = createContentProcessor(config);
+	const processor = await createContentProcessor(config);
 
 	async function build() {
 		log.info("Processing...");

--- a/packages/content-lib/src/index.ts
+++ b/packages/content-lib/src/index.ts
@@ -226,7 +226,7 @@ export interface ContentProcessor {
 	watch: () => Promise<Set<watcher.AsyncSubscription>>;
 }
 
-export function createContentProcessor(config: ContentConfig): ContentProcessor {
+export async function createContentProcessor(config: ContentConfig): Promise<ContentProcessor> {
 	debug("Creating content processor...\n");
 
 	const concurrency = availableParallelism();
@@ -246,6 +246,9 @@ export function createContentProcessor(config: ContentConfig): ContentProcessor 
 
 	for (const collection of config.collections) {
 		const absoluteDirectoryPath = addTrailingSlash(path.resolve(collection.directory));
+
+		/** Ensure directory exists, which is expected by `@parcel/watcher`. */
+		await fs.mkdir(absoluteDirectoryPath, { recursive: true });
 
 		const outputDirectoryPath = path.join(
 			outputDirectoryBasePath,


### PR DESCRIPTION
`@parcel/watcher` throws a "bad file descriptor" exception when the directory, which should be watched, does not exist.