### PR TITLE
feat: read config from file, inder type of imported modules

### DIFF
--- a/apps/basic/app/empty/page.tsx
+++ b/apps/basic/app/empty/page.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from "react";
+
+import { client } from "@/lib/content/client";
+
+export default function EmptyPage(): ReactNode {
+	return (
+		<main>
+			<h1>Items</h1>
+			<ul role="list">
+				{client.empty.all().map((item) => {
+					return <li key={item.id}>{item.metadata.name}</li>;
+				})}
+			</ul>
+		</main>
+	);
+}

--- a/apps/basic/lib/content/client.ts
+++ b/apps/basic/lib/content/client.ts
@@ -1,3 +1,4 @@
+import empty from "@content/empty";
 import people from "@content/people";
 import posts from "@content/posts";
 
@@ -51,6 +52,7 @@ function createCollectionClient<T extends { document: unknown }>(
 // }
 
 export const client = {
+	empty: createCollectionClient(empty),
 	people: createCollectionClient(people),
 	posts: createCollectionClient(posts),
 };

--- a/apps/basic/lib/content/collections/empty.ts
+++ b/apps/basic/lib/content/collections/empty.ts
@@ -6,17 +6,16 @@ import { read } from "to-vfile";
 import * as v from "valibot";
 import { matter } from "vfile-matter";
 
-export const posts = createCollection({
-	name: "posts",
-	directory: "./content/posts/",
-	include: ["*/index.md"],
+export const empty = createCollection({
+	name: "empty",
+	directory: "./content/empty/",
+	include: ["*.md"],
 	async read(item) {
 		const vfile = await read(item.absoluteFilePath);
 		matter(vfile, { strip: true });
 		const metadata = v.parse(
 			v.object({
-				title: v.pipe(v.string(), v.nonEmpty()),
-				authors: v.pipe(v.array(v.pipe(v.string(), v.nonEmpty())), v.minLength(1)),
+				name: v.pipe(v.string(), v.nonEmpty()),
 			}),
 			vfile.data.matter,
 		);

--- a/apps/basic/lib/content/collections/people.ts
+++ b/apps/basic/lib/content/collections/people.ts
@@ -1,5 +1,6 @@
 import { createCollection } from "@acdh-oeaw/content-lib";
 import { compile } from "@mdx-js/mdx";
+import type { MDXContent } from "mdx/types";
 import withGfm from "remark-gfm";
 import { read } from "to-vfile";
 import * as v from "valibot";
@@ -32,7 +33,7 @@ export const people = createCollection({
 		);
 		const metadata = data.metadata;
 		const content = String(vfile);
-		const module = context.createJavaScriptImport(content);
+		const module = context.createJavaScriptImport<MDXContent>(content);
 		return { content: module, metadata, id: item.id };
 	},
 });

--- a/apps/basic/lib/content/config.ts
+++ b/apps/basic/lib/content/config.ts
@@ -1,8 +1,9 @@
 import { createConfig } from "@acdh-oeaw/content-lib";
 
+import { empty } from "@/lib/content/collections/empty";
 import { people } from "@/lib/content/collections/people";
 import { posts } from "@/lib/content/collections/posts";
 
 export const config = createConfig({
-	collections: [posts, people],
+	collections: [empty, people, posts],
 });

--- a/apps/basic/package.json
+++ b/apps/basic/package.json
@@ -53,6 +53,7 @@
 		"@next/eslint-plugin-next": "catalog:",
 		"@playwright/test": "catalog:",
 		"@tailwindcss/postcss": "catalog:",
+		"@types/mdx": "catalog:",
 		"@types/node": "catalog:",
 		"@types/react": "catalog:",
 		"@types/react-dom": "catalog:",

--- a/apps/basic/scripts/generate-content.ts
+++ b/apps/basic/scripts/generate-content.ts
@@ -4,8 +4,6 @@ import { createContentProcessor } from "@acdh-oeaw/content-lib";
 import { log } from "@acdh-oeaw/lib";
 import * as v from "valibot";
 
-import { config } from "@/lib/content/config";
-
 const positionalArgsSchema = v.optional(v.picklist(["build", "watch"]), "build");
 
 const formatters = {
@@ -16,7 +14,9 @@ async function generate(): Promise<void> {
 	const { positionals } = parseArgs({ allowPositionals: true });
 	const mode = v.parse(positionalArgsSchema, positionals.at(0));
 
-	const processor = await createContentProcessor(config);
+	const processor = await createContentProcessor({
+		configFilePath: "./lib/content/config",
+	});
 
 	async function build() {
 		log.info("Processing...");

--- a/apps/bench/lib/content/collections/people.ts
+++ b/apps/bench/lib/content/collections/people.ts
@@ -1,5 +1,6 @@
 import { createCollection } from "@acdh-oeaw/content-lib";
 import { compile } from "@mdx-js/mdx";
+import type { MDXContent } from "mdx/types";
 import withGfm from "remark-gfm";
 import { read } from "to-vfile";
 import * as v from "valibot";
@@ -32,7 +33,7 @@ export const people = createCollection({
 		);
 		const metadata = data.metadata;
 		const content = String(vfile);
-		const module = context.createJavaScriptImport(content);
+		const module = context.createJavaScriptImport<MDXContent>(content);
 		return { content: module, metadata, id: item.id };
 	},
 });

--- a/apps/bench/lib/content/collections/posts.ts
+++ b/apps/bench/lib/content/collections/posts.ts
@@ -1,5 +1,6 @@
 import { createCollection } from "@acdh-oeaw/content-lib";
 import { compile } from "@mdx-js/mdx";
+import type { MDXContent } from "mdx/types";
 import withGfm from "remark-gfm";
 import { read } from "to-vfile";
 import * as v from "valibot";
@@ -33,7 +34,7 @@ export const posts = createCollection({
 		);
 		const metadata = data.metadata;
 		const content = String(vfile);
-		const module = context.createJavaScriptImport(content);
+		const module = context.createJavaScriptImport<MDXContent>(content);
 		return { content: module, metadata, id: item.id };
 	},
 });

--- a/apps/bench/lib/content/config.ts
+++ b/apps/bench/lib/content/config.ts
@@ -4,5 +4,5 @@ import { people } from "@/lib/content/collections/people";
 import { posts } from "@/lib/content/collections/posts";
 
 export const config = createConfig({
-	collections: [posts, people],
+	collections: [people, posts],
 });

--- a/apps/bench/package.json
+++ b/apps/bench/package.json
@@ -53,6 +53,7 @@
 		"@next/eslint-plugin-next": "catalog:",
 		"@playwright/test": "catalog:",
 		"@tailwindcss/postcss": "catalog:",
+		"@types/mdx": "catalog:",
 		"@types/node": "catalog:",
 		"@types/react": "catalog:",
 		"@types/react-dom": "catalog:",

--- a/apps/bench/scripts/generate-content.ts
+++ b/apps/bench/scripts/generate-content.ts
@@ -4,8 +4,6 @@ import { createContentProcessor } from "@acdh-oeaw/content-lib";
 import { log } from "@acdh-oeaw/lib";
 import * as v from "valibot";
 
-import { config } from "@/lib/content/config";
-
 const positionalArgsSchema = v.optional(v.picklist(["build", "watch"]), "build");
 
 const formatters = {
@@ -16,7 +14,9 @@ async function generate(): Promise<void> {
 	const { positionals } = parseArgs({ allowPositionals: true });
 	const mode = v.parse(positionalArgsSchema, positionals.at(0));
 
-	const processor = await createContentProcessor(config);
+	const processor = await createContentProcessor({
+		configFilePath: "./lib/content/config",
+	});
 
 	async function build() {
 		log.info("Processing...");

--- a/apps/keystatic/lib/content/collections/people.ts
+++ b/apps/keystatic/lib/content/collections/people.ts
@@ -1,5 +1,6 @@
 import { createCollection } from "@acdh-oeaw/content-lib";
 import { compile } from "@mdx-js/mdx";
+import type { MDXContent } from "mdx/types";
 import withGfm from "remark-gfm";
 import { VFile } from "vfile";
 
@@ -20,7 +21,7 @@ export const people = createCollection({
 			jsx: true,
 			remarkPlugins: [withGfm],
 		});
-		const module = context.createJavaScriptImport(String(output));
+		const module = context.createJavaScriptImport<MDXContent>(String(output));
 		return { id: item.id, content: module, metadata };
 	},
 });

--- a/apps/keystatic/lib/content/collections/posts.ts
+++ b/apps/keystatic/lib/content/collections/posts.ts
@@ -1,5 +1,6 @@
 import { createCollection } from "@acdh-oeaw/content-lib";
 import { compile } from "@mdx-js/mdx";
+import type { MDXContent } from "mdx/types";
 import withGfm from "remark-gfm";
 import { VFile } from "vfile";
 
@@ -20,7 +21,7 @@ export const posts = createCollection({
 			jsx: true,
 			remarkPlugins: [withGfm],
 		});
-		const module = context.createJavaScriptImport(String(output));
+		const module = context.createJavaScriptImport<MDXContent>(String(output));
 		return { id: item.id, content: module, metadata };
 	},
 });

--- a/apps/keystatic/lib/content/config.ts
+++ b/apps/keystatic/lib/content/config.ts
@@ -4,5 +4,5 @@ import { people } from "@/lib/content/collections/people";
 import { posts } from "@/lib/content/collections/posts";
 
 export const config = createConfig({
-	collections: [posts, people],
+	collections: [people, posts],
 });

--- a/apps/keystatic/scripts/generate-content.ts
+++ b/apps/keystatic/scripts/generate-content.ts
@@ -4,8 +4,6 @@ import { createContentProcessor } from "@acdh-oeaw/content-lib";
 import { log } from "@acdh-oeaw/lib";
 import * as v from "valibot";
 
-import { config } from "@/lib/content/config";
-
 const positionalArgsSchema = v.optional(v.picklist(["build", "watch"]), "build");
 
 const formatters = {
@@ -16,7 +14,9 @@ async function generate(): Promise<void> {
 	const { positionals } = parseArgs({ allowPositionals: true });
 	const mode = v.parse(positionalArgsSchema, positionals.at(0));
 
-	const processor = await createContentProcessor(config);
+	const processor = await createContentProcessor({
+		configFilePath: "./lib/content/config",
+	});
 
 	async function build() {
 		log.info("Processing...");

--- a/packages/content-lib/package.json
+++ b/packages/content-lib/package.json
@@ -34,7 +34,8 @@
 	"dependencies": {
 		"@acdh-oeaw/lib": "catalog:",
 		"@parcel/watcher": "catalog:",
-		"p-limit": "catalog:"
+		"p-limit": "catalog:",
+		"pluralize": "catalog:"
 	},
 	"devDependencies": {
 		"@acdh-oeaw/eslint-config": "catalog:",
@@ -43,6 +44,7 @@
 		"@acdh-oeaw/tsconfig": "catalog:",
 		"@acdh-oeaw/tsconfig-lib": "catalog:",
 		"@types/node": "catalog:",
+		"@types/pluralize": "catalog:",
 		"eslint": "catalog:",
 		"eslint-config-flat-gitignore": "catalog:",
 		"globals": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,22 +53,25 @@ catalogs:
       version: 3.1.0
     '@next/eslint-plugin-next':
       specifier: canary
-      version: 15.4.2-canary.55
+      version: 15.5.1-canary.3
     '@parcel/watcher':
       specifier: ^2.5.1
       version: 2.5.1
     '@playwright/test':
-      specifier: ^1.54.2
-      version: 1.54.2
+      specifier: ^1.55.0
+      version: 1.55.0
     '@tailwindcss/postcss':
       specifier: ^4.1.12
       version: 4.1.12
     '@types/mdx':
-      specifier: ^2.0.13
+      specifier: 2.0.13
       version: 2.0.13
     '@types/node':
       specifier: ^22.17.2
       version: 22.17.2
+    '@types/pluralize':
+      specifier: ^0.0.33
+      version: 0.0.33
     '@types/react':
       specifier: ^19.1.10
       version: 19.1.10
@@ -92,13 +95,13 @@ catalogs:
       version: 16.3.0
     is-in-ci:
       specifier: ^2.0.0
-      version: 1.0.0
+      version: 2.0.0
     lint-staged:
       specifier: ^16.1.5
       version: 16.1.5
     next:
       specifier: canary
-      version: 15.4.2-canary.55
+      version: 15.5.1-canary.3
     node:
       specifier: ^22.18.0
       version: 22.18.0
@@ -108,6 +111,9 @@ catalogs:
     p-limit:
       specifier: ^7.1.0
       version: 7.1.0
+    pluralize:
+      specifier: ^8.0.0
+      version: 8.0.0
     prettier:
       specifier: 3.6.2
       version: 3.6.2
@@ -172,10 +178,10 @@ importers:
         version: 2.29.6(@types/node@22.17.2)
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.54.2
+        version: 1.55.0
       is-in-ci:
         specifier: 'catalog:'
-        version: 1.0.0
+        version: 2.0.0
       lint-staged:
         specifier: 'catalog:'
         version: 16.1.5
@@ -208,7 +214,7 @@ importers:
         version: 0.3.4
       next:
         specifier: 'catalog:'
-        version: 15.4.2-canary.55(@babel/core@7.28.3)(@playwright/test@1.54.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 15.5.1-canary.3(@babel/core@7.28.3)(@playwright/test@1.55.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       react:
         specifier: 'catalog:'
         version: 19.1.1
@@ -224,7 +230,7 @@ importers:
         version: 2.0.9(@typescript-eslint/utils@8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(globals@16.3.0)(typescript@5.9.2)
       '@acdh-oeaw/eslint-config-next':
         specifier: 'catalog:'
-        version: 2.0.21(@acdh-oeaw/eslint-config-react@2.0.13(@acdh-oeaw/eslint-config@2.0.9(@typescript-eslint/utils@8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(globals@16.3.0)(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(ts-api-utils@2.1.0(typescript@5.9.2))(typescript@5.9.2))(@acdh-oeaw/eslint-config@2.0.9(@typescript-eslint/utils@8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(globals@16.3.0)(typescript@5.9.2))(@next/eslint-plugin-next@15.4.2-canary.55)
+        version: 2.0.21(@acdh-oeaw/eslint-config-react@2.0.13(@acdh-oeaw/eslint-config@2.0.9(@typescript-eslint/utils@8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(globals@16.3.0)(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(ts-api-utils@2.1.0(typescript@5.9.2))(typescript@5.9.2))(@acdh-oeaw/eslint-config@2.0.9(@typescript-eslint/utils@8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(globals@16.3.0)(typescript@5.9.2))(@next/eslint-plugin-next@15.5.1-canary.3)
       '@acdh-oeaw/eslint-config-node':
         specifier: 'catalog:'
         version: 2.0.9(@acdh-oeaw/eslint-config@2.0.9(@typescript-eslint/utils@8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(globals@16.3.0)(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)
@@ -248,13 +254,16 @@ importers:
         version: 3.1.0(acorn@8.15.0)
       '@next/eslint-plugin-next':
         specifier: 'catalog:'
-        version: 15.4.2-canary.55
+        version: 15.5.1-canary.3
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.54.2
+        version: 1.55.0
       '@tailwindcss/postcss':
         specifier: 'catalog:'
         version: 4.1.12
+      '@types/mdx':
+        specifier: 'catalog:'
+        version: 2.0.13
       '@types/node':
         specifier: 'catalog:'
         version: 22.17.2
@@ -281,7 +290,7 @@ importers:
         version: 16.3.0
       is-in-ci:
         specifier: 'catalog:'
-        version: 1.0.0
+        version: 2.0.0
       node:
         specifier: 'catalog:'
         version: 22.18.0
@@ -326,7 +335,7 @@ importers:
         version: 0.3.4
       next:
         specifier: 'catalog:'
-        version: 15.4.2-canary.55(@babel/core@7.28.3)(@playwright/test@1.54.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 15.5.1-canary.3(@babel/core@7.28.3)(@playwright/test@1.55.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       react:
         specifier: 'catalog:'
         version: 19.1.1
@@ -342,7 +351,7 @@ importers:
         version: 2.0.9(@typescript-eslint/utils@8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(globals@16.3.0)(typescript@5.9.2)
       '@acdh-oeaw/eslint-config-next':
         specifier: 'catalog:'
-        version: 2.0.21(@acdh-oeaw/eslint-config-react@2.0.13(@acdh-oeaw/eslint-config@2.0.9(@typescript-eslint/utils@8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(globals@16.3.0)(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(ts-api-utils@2.1.0(typescript@5.9.2))(typescript@5.9.2))(@acdh-oeaw/eslint-config@2.0.9(@typescript-eslint/utils@8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(globals@16.3.0)(typescript@5.9.2))(@next/eslint-plugin-next@15.4.2-canary.55)
+        version: 2.0.21(@acdh-oeaw/eslint-config-react@2.0.13(@acdh-oeaw/eslint-config@2.0.9(@typescript-eslint/utils@8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(globals@16.3.0)(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(ts-api-utils@2.1.0(typescript@5.9.2))(typescript@5.9.2))(@acdh-oeaw/eslint-config@2.0.9(@typescript-eslint/utils@8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(globals@16.3.0)(typescript@5.9.2))(@next/eslint-plugin-next@15.5.1-canary.3)
       '@acdh-oeaw/eslint-config-node':
         specifier: 'catalog:'
         version: 2.0.9(@acdh-oeaw/eslint-config@2.0.9(@typescript-eslint/utils@8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(globals@16.3.0)(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)
@@ -366,13 +375,16 @@ importers:
         version: 3.1.0(acorn@8.15.0)
       '@next/eslint-plugin-next':
         specifier: 'catalog:'
-        version: 15.4.2-canary.55
+        version: 15.5.1-canary.3
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.54.2
+        version: 1.55.0
       '@tailwindcss/postcss':
         specifier: 'catalog:'
         version: 4.1.12
+      '@types/mdx':
+        specifier: 'catalog:'
+        version: 2.0.13
       '@types/node':
         specifier: 'catalog:'
         version: 22.17.2
@@ -399,7 +411,7 @@ importers:
         version: 16.3.0
       is-in-ci:
         specifier: 'catalog:'
-        version: 1.0.0
+        version: 2.0.0
       node:
         specifier: 'catalog:'
         version: 22.18.0
@@ -444,7 +456,7 @@ importers:
         version: 0.3.4
       next:
         specifier: 'catalog:'
-        version: 15.4.2-canary.55(@babel/core@7.28.3)(@playwright/test@1.54.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 15.5.1-canary.3(@babel/core@7.28.3)(@playwright/test@1.55.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       react:
         specifier: 'catalog:'
         version: 19.1.1
@@ -460,7 +472,7 @@ importers:
         version: 2.0.9(@typescript-eslint/utils@8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(globals@16.3.0)(typescript@5.9.2)
       '@acdh-oeaw/eslint-config-next':
         specifier: 'catalog:'
-        version: 2.0.21(@acdh-oeaw/eslint-config-react@2.0.13(@acdh-oeaw/eslint-config@2.0.9(@typescript-eslint/utils@8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(globals@16.3.0)(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(ts-api-utils@2.1.0(typescript@5.9.2))(typescript@5.9.2))(@acdh-oeaw/eslint-config@2.0.9(@typescript-eslint/utils@8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(globals@16.3.0)(typescript@5.9.2))(@next/eslint-plugin-next@15.4.2-canary.55)
+        version: 2.0.21(@acdh-oeaw/eslint-config-react@2.0.13(@acdh-oeaw/eslint-config@2.0.9(@typescript-eslint/utils@8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(globals@16.3.0)(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(ts-api-utils@2.1.0(typescript@5.9.2))(typescript@5.9.2))(@acdh-oeaw/eslint-config@2.0.9(@typescript-eslint/utils@8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(globals@16.3.0)(typescript@5.9.2))(@next/eslint-plugin-next@15.5.1-canary.3)
       '@acdh-oeaw/eslint-config-node':
         specifier: 'catalog:'
         version: 2.0.9(@acdh-oeaw/eslint-config@2.0.9(@typescript-eslint/utils@8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(globals@16.3.0)(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)
@@ -481,19 +493,19 @@ importers:
         version: 1.5.1(typescript@5.9.2)
       '@keystatic/core':
         specifier: 'catalog:'
-        version: 0.5.48(next@15.4.2-canary.55(@playwright/test@1.54.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 0.5.48(next@15.5.1-canary.3(@babel/core@7.28.3)(@playwright/test@1.55.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@keystatic/next':
         specifier: 'catalog:'
-        version: 5.0.4(@keystatic/core@0.5.48(next@15.4.2-canary.55(@playwright/test@1.54.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(next@15.4.2-canary.55(@playwright/test@1.54.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 5.0.4(@keystatic/core@0.5.48(next@15.5.1-canary.3(@babel/core@7.28.3)(@playwright/test@1.55.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(next@15.5.1-canary.3(@babel/core@7.28.3)(@playwright/test@1.55.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@mdx-js/mdx':
         specifier: 'catalog:'
         version: 3.1.0(acorn@8.15.0)
       '@next/eslint-plugin-next':
         specifier: 'catalog:'
-        version: 15.4.2-canary.55
+        version: 15.5.1-canary.3
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.54.2
+        version: 1.55.0
       '@tailwindcss/postcss':
         specifier: 'catalog:'
         version: 4.1.12
@@ -526,7 +538,7 @@ importers:
         version: 16.3.0
       is-in-ci:
         specifier: 'catalog:'
-        version: 1.0.0
+        version: 2.0.0
       node:
         specifier: 'catalog:'
         version: 22.18.0
@@ -575,6 +587,9 @@ importers:
       p-limit:
         specifier: 'catalog:'
         version: 7.1.0
+      pluralize:
+        specifier: 'catalog:'
+        version: 8.0.0
     devDependencies:
       '@acdh-oeaw/eslint-config':
         specifier: 'catalog:'
@@ -594,6 +609,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 22.17.2
+      '@types/pluralize':
+        specifier: 'catalog:'
+        version: 0.0.33
       eslint:
         specifier: 'catalog:'
         version: 9.33.0(jiti@2.5.1)
@@ -1437,56 +1455,56 @@ packages:
   '@napi-rs/wasm-runtime@1.0.3':
     resolution: {integrity: sha512-rZxtMsLwjdXkMUGC3WwsPwLNVqVqnTJT6MNIB6e+5fhMcSCPP0AOsNWuMQ5mdCq6HNjs/ZeWAEchpqeprqBD2Q==}
 
-  '@next/env@15.4.2-canary.55':
-    resolution: {integrity: sha512-4SJCT+YY9bqOSu0uH3JCgCqR6v+PdUd8eZdCx3ipcwWBQQ1P1C0kFtSW3M80gS7nnzapMPEiQbpSfvb6gDxz1g==}
+  '@next/env@15.5.1-canary.3':
+    resolution: {integrity: sha512-gHPyUYSObFKEiP+DlDPcfLefdfIu3r253mLWxig0EeBWwlG4sgwNGPmhjptdIZuL0PIc+pwAbG84qOrOady0Iw==}
 
-  '@next/eslint-plugin-next@15.4.2-canary.55':
-    resolution: {integrity: sha512-oAxG5cHD+/s/HV18wbvQPFes0TxYfdOyOrBxL4k6VNYcH11ej0HGfMwtTrvMkar1XZLVNsE8qrXhmKqrHZSd/Q==}
+  '@next/eslint-plugin-next@15.5.1-canary.3':
+    resolution: {integrity: sha512-/1AbTq5EsDx3QMtdElG3MyLtdS2CoOOHKnDa72AD6uBnMCoF3Sn9FwiByKIxViPtVGKLzvRz/uMX2cPWGwDMCg==}
 
-  '@next/swc-darwin-arm64@15.4.2-canary.55':
-    resolution: {integrity: sha512-f4YO0TFWTQ7i3wje3DqR/xBJ4w6T+c/1ORfFUWLmhuX8XJF8jMcQf7GmKqloOPYYzIXcX452PSV2asuub+0qxA==}
+  '@next/swc-darwin-arm64@15.5.1-canary.3':
+    resolution: {integrity: sha512-kveKvspYODQ6sa67dFfM4eWZrlDlnULdrMAWWLeuZATdGyVgv4Z1mEYTkNsXZan6fJhjcFqc5hS5N8720YNwoQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@15.4.2-canary.55':
-    resolution: {integrity: sha512-XvCueejk+r1uQ7WYLLFy13Fy3XqJwrIxmMPzQny0omIv5YPF39ArRpLDthJQKvByDByLZFWnQSmaaTWlMJ6iWw==}
+  '@next/swc-darwin-x64@15.5.1-canary.3':
+    resolution: {integrity: sha512-bARgZNZNo3lkLZaexMyfB3abWUv22Sz5hR7KkngtupJTB7DMj9moJpzLVvCYpmpc6np7iFgFbVx9wCFbD+U6QQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@15.4.2-canary.55':
-    resolution: {integrity: sha512-c3EpUxuj/wL8HAeAIYKTuWCR90Cr69kYcW4k3kfmYz2gv/0I+H+HsW7fb95sA4VTnbGFvpve0YnTLjDoTzeD1A==}
+  '@next/swc-linux-arm64-gnu@15.5.1-canary.3':
+    resolution: {integrity: sha512-b9OWV28a37sT6+7ggZHvdiBLWQ7NTyXCaR5osoSFaAbb/q2TjjKxRQRDR12vKBL9fMbZSBu/wwy5X1dmblWvTw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@15.4.2-canary.55':
-    resolution: {integrity: sha512-M0WsCr6ZhmjyKBwrtyYT7zA+qmKooptN+7Ogjl0KDgB8wnj/W5X7ZLgs9bc4/22726XOy1JGOgQWF0KaiEFX9Q==}
+  '@next/swc-linux-arm64-musl@15.5.1-canary.3':
+    resolution: {integrity: sha512-dlMZ/tg+A0sSjl9GMNmlOE6ARII1MorXhl5q/4d0bdrHg+kBUV7r2NIcoS9dZOU8GK5Z8nxCK6yhdAs49kW+bA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@15.4.2-canary.55':
-    resolution: {integrity: sha512-Q3J05Hqgloji4aBmXmVXk7t3uMK1fRPmvtS7H4uCdwbSjqkkBYPDs6nE+J29jlWfEAaYNINJONXauhkajrRvAA==}
+  '@next/swc-linux-x64-gnu@15.5.1-canary.3':
+    resolution: {integrity: sha512-OVOE8LoWAk5ENBBU03V45Xz4xeF0ddh5GBbY7cVF2gBUKwHPatHboUf4zRNYwxBVGgRo7phbwvyuwVZYW9NBFQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@15.4.2-canary.55':
-    resolution: {integrity: sha512-nUyySGsAtvaHRbJmnfUOzaSVff9WcScNmf0dJn2TvN/DVw1jcnriFZySsXFiCfv5Zu5jFmPMovXIGLjQsTMNsQ==}
+  '@next/swc-linux-x64-musl@15.5.1-canary.3':
+    resolution: {integrity: sha512-eLadF0a0QU8hY5QYb3gEKtYaTGEtujM4dppsP0TzMaQ48wIYF8mngpFaUxAKkVy9AjM4lixEu6c4g543ZeqVCw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@15.4.2-canary.55':
-    resolution: {integrity: sha512-lS+0QrgTo62a2VBaV1B65kGh7HaScPOjObt3Btv3L6fU7hApnaEg5dwVsebQx9haJuQb7IcfVU3iGP6ceY7aIg==}
+  '@next/swc-win32-arm64-msvc@15.5.1-canary.3':
+    resolution: {integrity: sha512-DlQrR3FQ4Ego7KnQvNsy/8hHviupX9BHLj6j/kXHQKvoCSKxkgdejJzFPFPJAPeHJTlwK2v7TM1JccZChiz7+Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@15.4.2-canary.55':
-    resolution: {integrity: sha512-1cTmGHNli01OB4Y4fLktAzopwzl1YKvhFlDZ0J2M3sTQ+IiIaZbrMAUyBq+D/aoe0t1Bk20BlIjlS067NnFIGw==}
+  '@next/swc-win32-x64-msvc@15.5.1-canary.3':
+    resolution: {integrity: sha512-N1+55F+i4iIhQfBHuSVoxXog60x8FoXmbi7orcm4I5x7n/UMwi5ms36KTALVt62OnquR8s9m+59NrAb/TxdEEg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -1596,8 +1614,8 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@playwright/test@1.54.2':
-    resolution: {integrity: sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==}
+  '@playwright/test@1.55.0':
+    resolution: {integrity: sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2362,6 +2380,9 @@ packages:
 
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
+
+  '@types/pluralize@0.0.33':
+    resolution: {integrity: sha512-JOqsl+ZoCpP4e8TDke9W79FDcSgPAR0l6pixx2JHkhnRjvShyYiAYw2LVsnA7K08Y6DeOnaU6ujmENO4os/cYg==}
 
   '@types/react-dom@19.1.7':
     resolution: {integrity: sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==}
@@ -3692,9 +3713,9 @@ packages:
       eslint: '*'
       typescript: '>=4.7.4'
 
-  is-in-ci@1.0.0:
-    resolution: {integrity: sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==}
-    engines: {node: '>=18'}
+  is-in-ci@2.0.0:
+    resolution: {integrity: sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w==}
+    engines: {node: '>=20'}
     hasBin: true
 
   is-map@2.0.3:
@@ -3933,8 +3954,8 @@ packages:
     resolution: {integrity: sha512-SL0JY3DaxylDuo/MecFeiC+7pedM0zia33zl0vcjgwcq1q1FWWF1To9EIauPbl8GbMCU0R2e0uJ8bZunhYKD2g==}
     engines: {node: '>=20.0.0'}
 
-  local-pkg@1.1.1:
-    resolution: {integrity: sha512-WunYko2W1NcdfAFpuLUoucsgULmgDBRkdxHxWQ7mK0cQqwPiy8E1enjuRBrhLtZkB5iScJ1XIPdhVEFK8aOLSg==}
+  local-pkg@1.1.2:
+    resolution: {integrity: sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==}
     engines: {node: '>=14'}
 
   locate-path@5.0.0:
@@ -4225,8 +4246,8 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  next@15.4.2-canary.55:
-    resolution: {integrity: sha512-usuYQfgxejPPM29nYjhwJxiIV010Q09yLBS6VFe+HSYtteMoRMUfdhuoQ7/eRFoa1vJvt6SNatY81RjcQDNN8w==}
+  next@15.5.1-canary.3:
+    resolution: {integrity: sha512-nDysQsagr72lRiWuPHfeSz9ZGIjEFiPkPCOv3mmRCMYcdgZ6zr5KgXeH1D2eGtn3a/SBVpI71rNSgIKtMb84nw==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
     peerDependencies:
@@ -4418,18 +4439,22 @@ packages:
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
-  pkg-types@2.2.0:
-    resolution: {integrity: sha512-2SM/GZGAEkPp3KWORxQZns4M+WSeXbC2HEvmOIJe3Cmiv6ieAJvdVhDldtHqM5J1Y7MrR1XhkBT/rMlhh9FdqQ==}
+  pkg-types@2.3.0:
+    resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
-  playwright-core@1.54.2:
-    resolution: {integrity: sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==}
+  playwright-core@1.55.0:
+    resolution: {integrity: sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.54.2:
-    resolution: {integrity: sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==}
+  playwright@1.55.0:
+    resolution: {integrity: sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  pluralize@8.0.0:
+    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
+    engines: {node: '>=4'}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -4490,9 +4515,6 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
-
-  quansync@0.2.10:
-    resolution: {integrity: sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A==}
 
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
@@ -5276,11 +5298,11 @@ snapshots:
     optionalDependencies:
       graphql: 16.11.0
 
-  '@acdh-oeaw/eslint-config-next@2.0.21(@acdh-oeaw/eslint-config-react@2.0.13(@acdh-oeaw/eslint-config@2.0.9(@typescript-eslint/utils@8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(globals@16.3.0)(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(ts-api-utils@2.1.0(typescript@5.9.2))(typescript@5.9.2))(@acdh-oeaw/eslint-config@2.0.9(@typescript-eslint/utils@8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(globals@16.3.0)(typescript@5.9.2))(@next/eslint-plugin-next@15.4.2-canary.55)':
+  '@acdh-oeaw/eslint-config-next@2.0.21(@acdh-oeaw/eslint-config-react@2.0.13(@acdh-oeaw/eslint-config@2.0.9(@typescript-eslint/utils@8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(globals@16.3.0)(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(ts-api-utils@2.1.0(typescript@5.9.2))(typescript@5.9.2))(@acdh-oeaw/eslint-config@2.0.9(@typescript-eslint/utils@8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(globals@16.3.0)(typescript@5.9.2))(@next/eslint-plugin-next@15.5.1-canary.3)':
     dependencies:
       '@acdh-oeaw/eslint-config': 2.0.9(@typescript-eslint/utils@8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(globals@16.3.0)(typescript@5.9.2)
       '@acdh-oeaw/eslint-config-react': 2.0.13(@acdh-oeaw/eslint-config@2.0.9(@typescript-eslint/utils@8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(globals@16.3.0)(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(ts-api-utils@2.1.0(typescript@5.9.2))(typescript@5.9.2)
-      '@next/eslint-plugin-next': 15.4.2-canary.55
+      '@next/eslint-plugin-next': 15.5.1-canary.3
 
   '@acdh-oeaw/eslint-config-node@2.0.9(@acdh-oeaw/eslint-config@2.0.9(@typescript-eslint/utils@8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(globals@16.3.0)(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)':
     dependencies:
@@ -6174,7 +6196,7 @@ snapshots:
 
   '@juggle/resize-observer@3.4.0': {}
 
-  '@keystar/ui@0.7.19(next@15.4.2-canary.55(@playwright/test@1.54.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@keystar/ui@0.7.19(next@15.5.1-canary.3(@babel/core@7.28.3)(@playwright/test@1.55.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       '@babel/runtime': 7.28.3
       '@emotion/css': 11.13.5
@@ -6267,18 +6289,18 @@ snapshots:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
     optionalDependencies:
-      next: 15.4.2-canary.55(@babel/core@7.28.3)(@playwright/test@1.54.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      next: 15.5.1-canary.3(@babel/core@7.28.3)(@playwright/test@1.55.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@keystatic/core@0.5.48(next@15.4.2-canary.55(@playwright/test@1.54.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@keystatic/core@0.5.48(next@15.5.1-canary.3(@babel/core@7.28.3)(@playwright/test@1.55.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       '@babel/runtime': 7.28.3
       '@braintree/sanitize-url': 6.0.4
       '@emotion/weak-memoize': 0.3.1
       '@floating-ui/react': 0.24.8(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@internationalized/string': 3.2.7
-      '@keystar/ui': 0.7.19(next@15.4.2-canary.55(@playwright/test@1.54.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@keystar/ui': 0.7.19(next@15.5.1-canary.3(@babel/core@7.28.3)(@playwright/test@1.55.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@markdoc/markdoc': 0.4.0(@types/react@19.1.10)(react@19.1.1)
       '@react-aria/focus': 3.21.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@react-aria/i18n': 3.12.11(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -6349,13 +6371,13 @@ snapshots:
       - next
       - supports-color
 
-  '@keystatic/next@5.0.4(@keystatic/core@0.5.48(next@15.4.2-canary.55(@playwright/test@1.54.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(next@15.4.2-canary.55(@playwright/test@1.54.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@keystatic/next@5.0.4(@keystatic/core@0.5.48(next@15.5.1-canary.3(@babel/core@7.28.3)(@playwright/test@1.55.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(next@15.5.1-canary.3(@babel/core@7.28.3)(@playwright/test@1.55.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       '@babel/runtime': 7.28.3
-      '@keystatic/core': 0.5.48(next@15.4.2-canary.55(@playwright/test@1.54.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@keystatic/core': 0.5.48(next@15.5.1-canary.3(@babel/core@7.28.3)(@playwright/test@1.55.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@types/react': 19.1.10
       chokidar: 3.6.0
-      next: 15.4.2-canary.55(@babel/core@7.28.3)(@playwright/test@1.54.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      next: 15.5.1-canary.3(@babel/core@7.28.3)(@playwright/test@1.55.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
       server-only: 0.0.1
@@ -6426,34 +6448,34 @@ snapshots:
       '@tybys/wasm-util': 0.10.0
     optional: true
 
-  '@next/env@15.4.2-canary.55': {}
+  '@next/env@15.5.1-canary.3': {}
 
-  '@next/eslint-plugin-next@15.4.2-canary.55':
+  '@next/eslint-plugin-next@15.5.1-canary.3':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@15.4.2-canary.55':
+  '@next/swc-darwin-arm64@15.5.1-canary.3':
     optional: true
 
-  '@next/swc-darwin-x64@15.4.2-canary.55':
+  '@next/swc-darwin-x64@15.5.1-canary.3':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@15.4.2-canary.55':
+  '@next/swc-linux-arm64-gnu@15.5.1-canary.3':
     optional: true
 
-  '@next/swc-linux-arm64-musl@15.4.2-canary.55':
+  '@next/swc-linux-arm64-musl@15.5.1-canary.3':
     optional: true
 
-  '@next/swc-linux-x64-gnu@15.4.2-canary.55':
+  '@next/swc-linux-x64-gnu@15.5.1-canary.3':
     optional: true
 
-  '@next/swc-linux-x64-musl@15.4.2-canary.55':
+  '@next/swc-linux-x64-musl@15.5.1-canary.3':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@15.4.2-canary.55':
+  '@next/swc-win32-arm64-msvc@15.5.1-canary.3':
     optional: true
 
-  '@next/swc-win32-x64-msvc@15.4.2-canary.55':
+  '@next/swc-win32-x64-msvc@15.5.1-canary.3':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -6534,9 +6556,9 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@playwright/test@1.54.2':
+  '@playwright/test@1.55.0':
     dependencies:
-      playwright: 1.54.2
+      playwright: 1.55.0
 
   '@quansync/fs@0.1.4':
     dependencies:
@@ -7663,6 +7685,8 @@ snapshots:
       undici-types: 6.21.0
 
   '@types/parse-json@4.0.2': {}
+
+  '@types/pluralize@0.0.33': {}
 
   '@types/react-dom@19.1.7(@types/react@19.1.10)':
     dependencies:
@@ -9240,7 +9264,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  is-in-ci@1.0.0: {}
+  is-in-ci@2.0.0: {}
 
   is-map@2.0.3: {}
 
@@ -9451,10 +9475,10 @@ snapshots:
       rfdc: 1.4.1
       wrap-ansi: 9.0.0
 
-  local-pkg@1.1.1:
+  local-pkg@1.1.2:
     dependencies:
       mlly: 1.7.4
-      pkg-types: 2.2.0
+      pkg-types: 2.3.0
       quansync: 0.2.11
 
   locate-path@5.0.0:
@@ -10007,9 +10031,9 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@15.4.2-canary.55(@babel/core@7.28.3)(@playwright/test@1.54.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+  next@15.5.1-canary.3(@babel/core@7.28.3)(@playwright/test@1.55.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:
-      '@next/env': 15.4.2-canary.55
+      '@next/env': 15.5.1-canary.3
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001735
       postcss: 8.4.31
@@ -10017,15 +10041,15 @@ snapshots:
       react-dom: 19.1.1(react@19.1.1)
       styled-jsx: 5.1.6(@babel/core@7.28.3)(react@19.1.1)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.4.2-canary.55
-      '@next/swc-darwin-x64': 15.4.2-canary.55
-      '@next/swc-linux-arm64-gnu': 15.4.2-canary.55
-      '@next/swc-linux-arm64-musl': 15.4.2-canary.55
-      '@next/swc-linux-x64-gnu': 15.4.2-canary.55
-      '@next/swc-linux-x64-musl': 15.4.2-canary.55
-      '@next/swc-win32-arm64-msvc': 15.4.2-canary.55
-      '@next/swc-win32-x64-msvc': 15.4.2-canary.55
-      '@playwright/test': 1.54.2
+      '@next/swc-darwin-arm64': 15.5.1-canary.3
+      '@next/swc-darwin-x64': 15.5.1-canary.3
+      '@next/swc-linux-arm64-gnu': 15.5.1-canary.3
+      '@next/swc-linux-arm64-musl': 15.5.1-canary.3
+      '@next/swc-linux-x64-gnu': 15.5.1-canary.3
+      '@next/swc-linux-x64-musl': 15.5.1-canary.3
+      '@next/swc-win32-arm64-msvc': 15.5.1-canary.3
+      '@next/swc-win32-x64-msvc': 15.5.1-canary.3
+      '@playwright/test': 1.55.0
       sharp: 0.34.3
     transitivePeerDependencies:
       - '@babel/core'
@@ -10149,7 +10173,7 @@ snapshots:
 
   package-manager-detector@0.2.11:
     dependencies:
-      quansync: 0.2.10
+      quansync: 0.2.11
 
   parent-module@1.0.1:
     dependencies:
@@ -10202,19 +10226,21 @@ snapshots:
       mlly: 1.7.4
       pathe: 2.0.3
 
-  pkg-types@2.2.0:
+  pkg-types@2.3.0:
     dependencies:
       confbox: 0.2.2
       exsolve: 1.0.7
       pathe: 2.0.3
 
-  playwright-core@1.54.2: {}
+  playwright-core@1.55.0: {}
 
-  playwright@1.54.2:
+  playwright@1.55.0:
     dependencies:
-      playwright-core: 1.54.2
+      playwright-core: 1.55.0
     optionalDependencies:
       fsevents: 2.3.2
+
+  pluralize@8.0.0: {}
 
   possible-typed-array-names@1.1.0: {}
 
@@ -10291,8 +10317,6 @@ snapshots:
       prosemirror-transform: 1.10.4
 
   punycode@2.3.1: {}
-
-  quansync@0.2.10: {}
 
   quansync@0.2.11: {}
 
@@ -10843,7 +10867,7 @@ snapshots:
     dependencies:
       enhanced-resolve: 5.18.3
       jiti: 2.5.1
-      local-pkg: 1.1.1
+      local-pkg: 1.1.2
       tailwindcss: 4.1.12
 
   tailwindcss@4.1.12: {}
@@ -11025,7 +11049,7 @@ snapshots:
       '@quansync/fs': 0.1.4
       defu: 6.1.4
       jiti: 2.5.1
-      quansync: 0.2.10
+      quansync: 0.2.11
 
   undici-types@6.21.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,29 +3,30 @@ packages:
   - ./packages/*
 
 catalog:
-  "@acdh-oeaw/eslint-config": 2.0.9
-  "@acdh-oeaw/eslint-config-next": ^2.0.21
-  "@acdh-oeaw/eslint-config-node": 2.0.9
-  "@acdh-oeaw/eslint-config-playwright": ^2.0.10
-  "@acdh-oeaw/eslint-config-react": ^2.0.13
-  "@acdh-oeaw/eslint-config-tailwindcss": ^3.0.1
-  "@acdh-oeaw/lib": 0.3.4
-  "@acdh-oeaw/prettier-config": 2.0.1
-  "@acdh-oeaw/tsconfig": ^1.5.1
-  "@acdh-oeaw/tsconfig-lib": ^1.3.0
-  "@changesets/changelog-github": ^0.5.1
-  "@changesets/cli": ^2.29.6
-  "@keystatic/core": ^0.5.48
-  "@keystatic/next": ^5.0.4
-  "@mdx-js/mdx": ^3.1.0
-  "@next/eslint-plugin-next": canary
-  "@parcel/watcher": ^2.5.1
-  "@playwright/test": ^1.54.2
-  "@tailwindcss/postcss": ^4.1.12
-  "@types/mdx": ^2.0.13
-  "@types/node": ^22.17.2
-  "@types/react": ^19.1.10
-  "@types/react-dom": ^19.1.7
+  '@acdh-oeaw/eslint-config': 2.0.9
+  '@acdh-oeaw/eslint-config-next': ^2.0.21
+  '@acdh-oeaw/eslint-config-node': 2.0.9
+  '@acdh-oeaw/eslint-config-playwright': ^2.0.10
+  '@acdh-oeaw/eslint-config-react': ^2.0.13
+  '@acdh-oeaw/eslint-config-tailwindcss': ^3.0.1
+  '@acdh-oeaw/lib': 0.3.4
+  '@acdh-oeaw/prettier-config': 2.0.1
+  '@acdh-oeaw/tsconfig': ^1.5.1
+  '@acdh-oeaw/tsconfig-lib': ^1.3.0
+  '@changesets/changelog-github': ^0.5.1
+  '@changesets/cli': ^2.29.6
+  '@keystatic/core': ^0.5.48
+  '@keystatic/next': ^5.0.4
+  '@mdx-js/mdx': ^3.1.0
+  '@next/eslint-plugin-next': canary
+  '@parcel/watcher': ^2.5.1
+  '@playwright/test': ^1.55.0
+  '@tailwindcss/postcss': ^4.1.12
+  '@types/mdx': 2.0.13
+  '@types/node': ^22.17.2
+  '@types/pluralize': ^0.0.33
+  '@types/react': ^19.1.10
+  '@types/react-dom': ^19.1.7
   concurrently: 9.2.0
   dotenv-cli: 10.0.0
   eslint: 9.33.0
@@ -37,6 +38,7 @@ catalog:
   node: ^22.18.0
   npm-run-all2: 8.0.4
   p-limit: ^7.1.0
+  pluralize: ^8.0.0
   prettier: 3.6.2
   react: ^19.1.1
   react-dom: ^19.1.1
@@ -59,8 +61,8 @@ catalogMode: strict
 cleanupUnusedCatalogs: true
 
 onlyBuiltDependencies:
-  - "@parcel/watcher"
-  - "@tailwindcss/oxide"
+  - '@parcel/watcher'
+  - '@tailwindcss/oxide'
   - esbuild
   - node
   - sharp


### PR DESCRIPTION
- changes `createContentProcessor` to accept a path to a config file instead of a config object.
- creates explicit `index.d.ts` for each collection, instead of relying on type inference. this is necessary so
  - empty collections still get correct types 
  - we can replace `JavascriptImport` and `JsonImport` types with the type of the module. this type is taken from a generic which now has to be passed to `createJavaScriptImport`, `createJsonImport` and `createImportDeclaration`.