### PR TITLE
fix: always save js module as .jsx file

### DIFF
--- a/.changeset/brown-bikes-mate.md
+++ b/.changeset/brown-bikes-mate.md
@@ -1,0 +1,5 @@
+---
+"@acdh-oeaw/content-lib": patch
+---
+
+always save js module as .jsx file

--- a/packages/content-lib/src/index.ts
+++ b/packages/content-lib/src/index.ts
@@ -216,7 +216,7 @@ function serialize(
 
 			if (value instanceof JavaScriptImport) {
 				const hash = createContentHash(value.content);
-				const filePath = `./${hash}.js`;
+				const filePath = `./${hash}.jsx`;
 
 				debug(`Adding javascript import for "${filePath}".`);
 				const identifier = addImport(filePath);


### PR DESCRIPTION
some tools (e.g. `tsx`) will not parse jsx syntax in `.js` files, but require an explicit `.jsx` extension. this is relevant when using the generated data in scripts and running them with `tsx`.

this changes the default file extension for `JavaScriptImport`s to `.jsx`.

in the future we may want to switch to `.tsx` since this will have to be processed by a transpiler/bundler anyway. 